### PR TITLE
Make TCO compilable with OSR loop nodes.

### DIFF
--- a/TruffleScheme/language/src/main/java/com/ihorak/truffle/convertor/ProcedureCallConverter.java
+++ b/TruffleScheme/language/src/main/java/com/ihorak/truffle/convertor/ProcedureCallConverter.java
@@ -9,6 +9,7 @@ import com.ihorak.truffle.node.callable.TCO.TailCallCatcherNode;
 import com.ihorak.truffle.node.callable.TCO.TailCallThrowerNodeGen;
 import com.ihorak.truffle.type.SchemeCell;
 import com.ihorak.truffle.type.SchemeSymbol;
+import com.oracle.truffle.api.frame.FrameSlotKind;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -41,10 +42,13 @@ public class ProcedureCallConverter {
         var callable = InternalRepresentationConverter.convert(operand, context, false);
       //  var callNode = new CallableExprNode(arguments, callable);
 //
+        
         if (isTailCall) {
             return TailCallThrowerNodeGen.create(arguments, callable);
         } else {
-            return new TailCallCatcherNode(arguments, callable);
+        	int tailCallArgumentsSlot = context.getFrameDescriptorBuilder().addSlot(FrameSlotKind.Object, null, null);
+        	int tailCallTargetSlot = context.getFrameDescriptorBuilder().addSlot(FrameSlotKind.Object, null, null);
+            return new TailCallCatcherNode(arguments, callable, tailCallArgumentsSlot, tailCallTargetSlot);
         }
 
      // return callNode;

--- a/TruffleScheme/language/src/main/java/com/ihorak/truffle/node/callable/CallableExprNode.java
+++ b/TruffleScheme/language/src/main/java/com/ihorak/truffle/node/callable/CallableExprNode.java
@@ -39,7 +39,6 @@ public class CallableExprNode extends SchemeExpression {
     public Object executeGeneric(final VirtualFrame frame) {
         var function = (UserDefinedProcedure) callable.executeGeneric(frame);
         var args = getProcedureOrMacroArgsNoOptional(function, frame);
-
         return call(function.getCallTarget(), args, frame);
     }
 

--- a/TruffleScheme/language/src/main/java/com/ihorak/truffle/node/exprs/builtin/WhileInfiniteExprNode.java
+++ b/TruffleScheme/language/src/main/java/com/ihorak/truffle/node/exprs/builtin/WhileInfiniteExprNode.java
@@ -1,21 +1,35 @@
 package com.ihorak.truffle.node.exprs.builtin;
 
 import com.ihorak.truffle.node.SchemeExpression;
+import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.LoopNode;
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.nodes.RepeatingNode;
 
 public class WhileInfiniteExprNode extends SchemeExpression {
 
     @Child
     private SchemeExpression expr;
 
+    @Child LoopNode loop;
+    
     public WhileInfiniteExprNode(final SchemeExpression expr) {
         this.expr = expr;
+        this.loop = Truffle.getRuntime().createLoopNode(new RepeatInfiniteNode());
     }
 
+    final class RepeatInfiniteNode extends Node implements RepeatingNode {
+    	@Override
+		public boolean executeRepeating(VirtualFrame frame) {
+			expr.executeGeneric(frame);
+			return true;
+		}
+    	
+    }
+    
     @Override
     public Object executeGeneric(final VirtualFrame virtualFrame) {
-        while (true) {
-            expr.executeGeneric(virtualFrame);
-        }
+    	return loop.execute(virtualFrame);
     }
 }


### PR DESCRIPTION
This should fix the compilation with OSR. 
There were a few issues:
1) The first call was always handled by the direct call and not the loop node
2) arguments and call target were stored in the node instead of the frame (which is particularly bad for recursive functions)
3) the while(true) loop also needs an OSR loop to get compiled.


Unfortunately, the compilation is not as good with OSR as with for regular call targets.
You see this by looking at the IGV graph where the frame is materialized (not escape analysed)
But it is also not extremely bad.